### PR TITLE
Removed require:true from latitude and longitude. We don't actually h…

### DIFF
--- a/server/models/event.model.js
+++ b/server/models/event.model.js
@@ -37,13 +37,11 @@ const EventSchema = new mongoose.Schema({
     },
 
     longitude: {
-        type: String,
-        required: true,
+        type: String
     },
 
     latitude: {
-        type: String,
-        require: true,
+        type: String
     },
 
     updated: Date,


### PR DESCRIPTION
…ave them when the record is initially created - that comes later with the geocoding function - so it was throwing an error when trying to create new records.